### PR TITLE
chore: Bump Multiplex version

### DIFF
--- a/com.pojtinger.felicitas.Multiplex.json
+++ b/com.pojtinger.felicitas.Multiplex.json
@@ -31,8 +31,8 @@
         {
           "type": "git",
           "url": "https://github.com/pojntfx/multiplex.git",
-          "tag": "v0.1.0",
-          "commit": "09b08c412c150bfcc13ddc6d82caf3e10fe8a7d6"
+          "tag": "v0.1.1",
+          "commit": "3ae99f11efd88e88f3768c7ca8d06e0538a20cb9"
         },
         "dependencies.json"
       ]


### PR DESCRIPTION
This bumps Multiplex to v0.1.1.