### PR TITLE
Bump GNOME runtime

### DIFF
--- a/com.pojtinger.felicitas.Multiplex.json
+++ b/com.pojtinger.felicitas.Multiplex.json
@@ -49,8 +49,7 @@
         {
           "type": "git",
           "url": "https://github.com/pojntfx/multiplex.git",
-          "tag": "v0.1.7",
-          "commit": "1a310a81a19bef54888d619684606a4ff7c3c688"
+          "commit": "13f5d7c677ff2b6d3238c913b1165747b7855a6a"
         },
         "go.mod.json"
       ]

--- a/com.pojtinger.felicitas.Multiplex.json
+++ b/com.pojtinger.felicitas.Multiplex.json
@@ -6,11 +6,11 @@
   "sdk-extensions": ["org.freedesktop.Sdk.Extension.golang"],
   "command": "multiplex",
   "finish-args": [
-    "--share=network",
+    "--socket=wayland",
     "--socket=fallback-x11",
     "--share=ipc",
-    "--socket=wayland",
     "--device=dri",
+    "--share=network",
     "--filesystem=xdg-download:rw",
     "--filesystem=xdg-videos:rw",
     "--filesystem=/tmp:rw",
@@ -41,9 +41,10 @@
       "build-commands": [
         "mkdir -p vendor && cp modules.txt vendor/modules.txt",
         ". /usr/lib/sdk/golang/enable.sh && export GOBIN=\"/app/bin\" && go generate ./... && go install -v -mod=vendor .",
-        "desktop-file-install --dir=/app/share/applications $FLATPAK_ID.desktop",
-        "install -D -m 0644 internal/resources/$FLATPAK_ID.metainfo.xml /app/share/metainfo/$FLATPAK_ID.metainfo.xml",
-        "for icon in 16x16 22x22 24x24 32x32 36x36 48x48 64x64 72x72 96x96 128x128 192x192 256x256 512x512; do install -D -m 0644 docs/icon-${icon}.png /app/share/icons/hicolor/${icon}/apps/$FLATPAK_ID.png; done"
+        "desktop-file-install --dir=/app/share/applications assets/meta/$FLATPAK_ID.desktop",
+        "install -D -m 0644 assets/resources/metainfo.xml /app/share/metainfo/$FLATPAK_ID.metainfo.xml",
+        "install -D -m 0644 assets/meta/icon.svg /app/share/icons/hicolor/scalable/apps/$FLATPAK_ID.svg",
+        "mkdir -p /app/share/locale && cp -r po/* /app/share/locale/"
       ],
       "sources": [
         {

--- a/com.pojtinger.felicitas.Multiplex.json
+++ b/com.pojtinger.felicitas.Multiplex.json
@@ -50,7 +50,13 @@
         {
           "type": "git",
           "url": "https://github.com/pojntfx/multiplex.git",
-          "commit": "13f5d7c677ff2b6d3238c913b1165747b7855a6a"
+          "tag": "v0.1.8",
+          "commit": "2ee2df257a6b3f2ac5dae01b0b87874336cf41aa",
+          "x-checker-data": {
+            "type": "git",
+            "tag-pattern": "^v([\\d.]+)$",
+            "version-scheme": "semantic"
+          }
         },
         "go.mod.json"
       ]

--- a/com.pojtinger.felicitas.Multiplex.json
+++ b/com.pojtinger.felicitas.Multiplex.json
@@ -51,7 +51,7 @@
           "type": "git",
           "url": "https://github.com/pojntfx/multiplex.git",
           "tag": "v0.1.8",
-          "commit": "2ee2df257a6b3f2ac5dae01b0b87874336cf41aa",
+          "commit": "061dbb1bc35c3e8b3f3ea6e6ffb1b38614c13438",
           "x-checker-data": {
             "type": "git",
             "tag-pattern": "^v([\\d.]+)$",

--- a/com.pojtinger.felicitas.Multiplex.json
+++ b/com.pojtinger.felicitas.Multiplex.json
@@ -1,7 +1,7 @@
 {
   "id": "com.pojtinger.felicitas.Multiplex",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "47",
+  "runtime-version": "49",
   "sdk": "org.gnome.Sdk",
   "sdk-extensions": ["org.freedesktop.Sdk.Extension.golang"],
   "command": "multiplex",
@@ -25,7 +25,13 @@
         {
           "type": "git",
           "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-          "tag": "v0.16.0"
+          "tag": "v0.18.0",
+          "x-checker-data": {
+            "type": "git",
+            "tag-pattern": "^v([\\d.]+)$",
+            "version-scheme": "semantic"
+          },
+          "commit": "07c9c9df9cd1b6b4454ecba21ee58211e9144a4b"
         }
       ]
     },

--- a/go.mod.json
+++ b/go.mod.json
@@ -1,24 +1,17 @@
 [
   {
     "dest": "vendor/github.com/anacrolix/torrent",
-    "sha256": "12b34284224c74753aba2eb48bf8116599b3c508c6ec39604420086ee4bfb6df",
+    "sha256": "1647a81aea7836a6010000fe38409defd5cc28c0b24bbee256bbfd40a48dbc39",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/anacrolix/torrent/@v/v1.58.1.zip"
+    "url": "https://proxy.golang.org/github.com/anacrolix/torrent/@v/v1.59.1.zip"
   },
   {
-    "dest": "vendor/github.com/diamondburned/gotk4-adwaita/pkg",
-    "sha256": "056e6a0bac70556f4783426bbfedb91f336f9a1178e4468e68ff8e7e2729c191",
-    "strip-components": 4,
+    "dest": "vendor/github.com/jwijenbergh/puregotk",
+    "sha256": "e0250ddaa1fcbf9fabf60e1bc132994ca32cd007032d112c684353f30ef6b729",
+    "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/diamondburned/gotk4-adwaita/pkg/@v/v0.0.0-20250223021911-503726bcfce6.zip"
-  },
-  {
-    "dest": "vendor/github.com/diamondburned/gotk4/pkg",
-    "sha256": "c9723192c5123d33d85cfbc39631f8246a76f767b44b36fb27f4366e7d8acdcd",
-    "strip-components": 4,
-    "type": "archive",
-    "url": "https://proxy.golang.org/github.com/diamondburned/gotk4/pkg/@v/v0.3.1.zip"
+    "url": "https://proxy.golang.org/github.com/pojntfx/puregotk/@v/v0.0.0-20251025231904-c77cab625c00.zip"
   },
   {
     "dest": "vendor/github.com/mitchellh/mapstructure",
@@ -35,6 +28,13 @@
     "url": "https://proxy.golang.org/github.com/phayes/freeport/@v/v0.0.0-20220201140144-74d24b5ae9f5.zip"
   },
   {
+    "dest": "vendor/github.com/pojntfx/go-gettext",
+    "sha256": "f2c433c3a070aa3164fa95757c21cd6a754b1d8e2038aca7fc5c056466377821",
+    "strip-components": 3,
+    "type": "archive",
+    "url": "https://proxy.golang.org/github.com/pojntfx/go-gettext/@v/v0.1.2.zip"
+  },
+  {
     "dest": "vendor/github.com/pojntfx/htorrent",
     "sha256": "414aa10c4a26423526618576f6773ad9182cd75a342d2e7d57fe3b1b5af291eb",
     "strip-components": 3,
@@ -43,24 +43,24 @@
   },
   {
     "dest": "vendor/github.com/pojntfx/weron",
-    "sha256": "f47dd69f079adb3cd6ac32d17a10e8daa0a3a4eb085c2864a8f974d6cc2df298",
+    "sha256": "6b454c413ab82ec4810afc2c03045b72df35f84fe6dc6f51475414b58542e0bd",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/pojntfx/weron/@v/v0.2.7.zip"
+    "url": "https://proxy.golang.org/github.com/pojntfx/weron/@v/v0.3.0.zip"
   },
   {
     "dest": "vendor/github.com/rs/zerolog",
-    "sha256": "ae98d0882a46553680e2a46aff41fd78ddaba44d4fafe30fc29bd2d57f59a064",
+    "sha256": "2edf6294b838727c208831325d8a7951e8084c7b37f125381d8254747c4987e3",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/rs/zerolog/@v/v1.33.0.zip"
+    "url": "https://proxy.golang.org/github.com/rs/zerolog/@v/v1.34.0.zip"
   },
   {
     "dest": "vendor/github.com/rymdport/portal",
-    "sha256": "28aec7619b480b3f26ad4aa7be2b2f4842eb36aca1a6a7463f8b5538218f8c28",
+    "sha256": "433ccc7d9646ae7f68570052ed06071b0881466f9203705f7cc6b6a6991069fe",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/rymdport/portal/@v/v0.4.1.zip"
+    "url": "https://proxy.golang.org/github.com/rymdport/portal/@v/v0.4.2.zip"
   },
   {
     "dest": "vendor/github.com/teivah/broadcast",
@@ -75,13 +75,6 @@
     "strip-components": 3,
     "type": "archive",
     "url": "https://proxy.golang.org/github.com/teris-io/shortid/@v/v0.0.0-20220617161101-71ec9f2aa569.zip"
-  },
-  {
-    "dest": "vendor/github.com/KarpelesLab/weak",
-    "sha256": "95beab3258f52af7133a707f6e6dc53f52e84dc7d81857b9022267146e3fdc0e",
-    "strip-components": 3,
-    "type": "archive",
-    "url": "https://proxy.golang.org/github.com/!karpeles!lab/weak/@v/v0.1.1.zip"
   },
   {
     "dest": "vendor/github.com/RoaringBitmap/roaring",
@@ -106,17 +99,17 @@
   },
   {
     "dest": "vendor/github.com/anacrolix/chansync",
-    "sha256": "db46943857fe3c2a0cddad514886b5ed8ee23bc6026390938479082b9f831c7b",
+    "sha256": "0667d52c9bfbd117cb4336d2687876ed7b2c2b85ff5a4374ea75a7a3e8daa7e1",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/anacrolix/chansync/@v/v0.6.0.zip"
+    "url": "https://proxy.golang.org/github.com/anacrolix/chansync/@v/v0.7.0.zip"
   },
   {
     "dest": "vendor/github.com/anacrolix/dht/v2",
-    "sha256": "58672c3a4cb0a948dad41a63cc9e8df062c9cdcf9449095739545826a1a21171",
+    "sha256": "a4147034c1059fb2f27c95ad203ce13771f2b5b95132a701ad7a6fae948f5592",
     "strip-components": 4,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/anacrolix/dht/v2/@v/v2.22.1.zip"
+    "url": "https://proxy.golang.org/github.com/anacrolix/dht/v2/@v/v2.23.0.zip"
   },
   {
     "dest": "vendor/github.com/anacrolix/envpprof",
@@ -127,10 +120,10 @@
   },
   {
     "dest": "vendor/github.com/anacrolix/generics",
-    "sha256": "cd0fe05e1deaefe9990d51f6481a6ef25414d0226f85956bb2cc629b32bc825f",
+    "sha256": "652e86d6be380e78c498867bde42d18fa520026b4718e5efb3b8e5b6bd2d9e0c",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/anacrolix/generics/@v/v0.0.3-0.20240902042256-7fb2702ef0ca.zip"
+    "url": "https://proxy.golang.org/github.com/anacrolix/generics/@v/v0.1.0.zip"
   },
   {
     "dest": "vendor/github.com/anacrolix/go-libutp",
@@ -141,10 +134,10 @@
   },
   {
     "dest": "vendor/github.com/anacrolix/log",
-    "sha256": "d18e75b879afe64a4b3b20b26c911bee3ae10d6da66e0e1d5636c401a5885faf",
+    "sha256": "e9d0085bf19492bf2d973e1688b1f5d8c3498cef17c601d29db7fa92541046e0",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/anacrolix/log/@v/v0.16.0.zip"
+    "url": "https://proxy.golang.org/github.com/anacrolix/log/@v/v0.17.0.zip"
   },
   {
     "dest": "vendor/github.com/anacrolix/missinggo",
@@ -162,10 +155,10 @@
   },
   {
     "dest": "vendor/github.com/anacrolix/missinggo/v2",
-    "sha256": "a6e5380e756454bb249c5e32d24c71ce3eebfcc7de091213066cd19336e12707",
+    "sha256": "7bdc5476048ff72bdd80f2eb4434c0ad8c25581d936f09d39740f6b27e49935a",
     "strip-components": 4,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/anacrolix/missinggo/v2/@v/v2.8.0.zip"
+    "url": "https://proxy.golang.org/github.com/anacrolix/missinggo/v2/@v/v2.10.0.zip"
   },
   {
     "dest": "vendor/github.com/anacrolix/mmsg",
@@ -190,10 +183,10 @@
   },
   {
     "dest": "vendor/github.com/anacrolix/sync",
-    "sha256": "8e3d1841c926da41347d10fd10cc9036631d56b36aca65df51ad0087d1b01a39",
+    "sha256": "68ad34bafd61dbd03cb36fcd72c234d6b840c4f578695139a05d2569322dd3fd",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/anacrolix/sync/@v/v0.5.3.zip"
+    "url": "https://proxy.golang.org/github.com/anacrolix/sync/@v/v0.5.4.zip"
   },
   {
     "dest": "vendor/github.com/anacrolix/upnp",
@@ -225,10 +218,10 @@
   },
   {
     "dest": "vendor/github.com/bits-and-blooms/bitset",
-    "sha256": "8ae8449afbc2e09203f838b070a11f689ff157b18e02c42f91ea10f5ba12227f",
+    "sha256": "b6d80a26b5d6b00c2d624968e78bb7eed8796898dacf5bdecc5e37f11f4c0098",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/bits-and-blooms/bitset/@v/v1.22.0.zip"
+    "url": "https://proxy.golang.org/github.com/bits-and-blooms/bitset/@v/v1.24.3.zip"
   },
   {
     "dest": "vendor/github.com/bradfitz/iter",
@@ -246,10 +239,10 @@
   },
   {
     "dest": "vendor/github.com/coreos/go-oidc/v3",
-    "sha256": "b6d2819d1f8f014968e8da51952847bee07a206fc917a501a17a17b8f3c2b505",
+    "sha256": "738ce35563917e1d08703fa602be8f0a73b1be7f927b5bb563c76b13fc73b37d",
     "strip-components": 4,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/coreos/go-oidc/v3/@v/v3.13.0.zip"
+    "url": "https://proxy.golang.org/github.com/coreos/go-oidc/v3/@v/v3.16.0.zip"
   },
   {
     "dest": "vendor/github.com/davecgh/go-spew",
@@ -257,6 +250,13 @@
     "strip-components": 3,
     "type": "archive",
     "url": "https://proxy.golang.org/github.com/davecgh/go-spew/@v/v1.1.2-0.20180830191138-d8f796af33cc.zip"
+  },
+  {
+    "dest": "vendor/github.com/dennwc/flatpak-go-mod",
+    "sha256": "4dfef87032d0e58e9bc469f8fc3cc378207a9ce548b2118bb9f0afa7c45446c0",
+    "strip-components": 3,
+    "type": "archive",
+    "url": "https://proxy.golang.org/github.com/dennwc/flatpak-go-mod/@v/v0.1.0.zip"
   },
   {
     "dest": "vendor/github.com/dustin/go-humanize",
@@ -273,11 +273,18 @@
     "url": "https://proxy.golang.org/github.com/edsrzf/mmap-go/@v/v1.2.0.zip"
   },
   {
+    "dest": "vendor/github.com/fatih/color",
+    "sha256": "e1b2da810ca48a16d9ecd808b7aaae757f1c3c906cf1e8ca1d149b8db7cdb91b",
+    "strip-components": 3,
+    "type": "archive",
+    "url": "https://proxy.golang.org/github.com/fatih/color/@v/v1.10.0.zip"
+  },
+  {
     "dest": "vendor/github.com/go-jose/go-jose/v4",
-    "sha256": "7bb0205c235a4bc2bbca729a08d2d86f31ac0199cfc1c70b2d780f7594366407",
+    "sha256": "ec019b110f6cdc3f55f067f52573be4474d5051b9b7c7fc11eb846b13c56beb4",
     "strip-components": 4,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/go-jose/go-jose/v4/@v/v4.0.5.zip"
+    "url": "https://proxy.golang.org/github.com/go-jose/go-jose/v4/@v/v4.1.3.zip"
   },
   {
     "dest": "vendor/github.com/go-llsqlite/adapter",
@@ -288,17 +295,17 @@
   },
   {
     "dest": "vendor/github.com/go-llsqlite/crawshaw",
-    "sha256": "7c3dcd2bc696187677b30be7f425fbd138eeda64a1d54f66cc8796965493f9da",
+    "sha256": "5b8e70745be798792f028dc54ec8c10d069c6244d3af590fd32bbe1de4cfe80c",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/go-llsqlite/crawshaw/@v/v0.5.5.zip"
+    "url": "https://proxy.golang.org/github.com/go-llsqlite/crawshaw/@v/v0.6.0.zip"
   },
   {
     "dest": "vendor/github.com/go-logr/logr",
-    "sha256": "9f8926fda6dee61e68522421963d5804baeb10024aa02b318d9bd50fdcfdd7d1",
+    "sha256": "523d7a3587fe73f61ef41c8bc627f7d7f38de8104d46278154b307e60770ad70",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/go-logr/logr/@v/v1.4.2.zip"
+    "url": "https://proxy.golang.org/github.com/go-logr/logr/@v/v1.4.3.zip"
   },
   {
     "dest": "vendor/github.com/go-logr/stdr",
@@ -306,6 +313,13 @@
     "strip-components": 3,
     "type": "archive",
     "url": "https://proxy.golang.org/github.com/go-logr/stdr/@v/v1.2.2.zip"
+  },
+  {
+    "dest": "vendor/github.com/goccy/go-yaml",
+    "sha256": "56119e93ed4c93fe38dc32c0d4ee45a66a1e524a865190ed864c7225bed4608e",
+    "strip-components": 3,
+    "type": "archive",
+    "url": "https://proxy.golang.org/github.com/goccy/go-yaml/@v/v1.12.0.zip"
   },
   {
     "dest": "vendor/github.com/godbus/dbus/v5",
@@ -350,11 +364,18 @@
     "url": "https://proxy.golang.org/github.com/json-iterator/go/@v/v1.1.12.zip"
   },
   {
+    "dest": "vendor/github.com/jwijenbergh/purego",
+    "sha256": "aa4903b6c7333843f77e6012d68c89846462f4755fe6201a4069e69547d1000e",
+    "strip-components": 3,
+    "type": "archive",
+    "url": "https://proxy.golang.org/github.com/jwijenbergh/purego/@v/v0.0.0-20251017112123-b71757b9ba42.zip"
+  },
+  {
     "dest": "vendor/github.com/klauspost/cpuid/v2",
-    "sha256": "db89665fa22cef477dc551b72d49707c516b749c17ed154bf67eb8081ee08dff",
+    "sha256": "e6766f75ecfadf12fd045e4bdd9383f2a5bd3f9bd4c88a6db72861c84cf41486",
     "strip-components": 4,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/klauspost/cpuid/v2/@v/v2.2.10.zip"
+    "url": "https://proxy.golang.org/github.com/klauspost/cpuid/v2/@v/v2.3.0.zip"
   },
   {
     "dest": "vendor/github.com/mattn/go-colorable",
@@ -414,17 +435,17 @@
   },
   {
     "dest": "vendor/github.com/multiformats/go-varint",
-    "sha256": "c22d63b0848740cf5b727baed82aace1fa4cd66280676af2e643526d8cf6c594",
+    "sha256": "d8bd26cabebdd7f245b8f81dbd85a3dc1d5b43e9fa0d320809526e0d616204dd",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/multiformats/go-varint/@v/v0.0.7.zip"
+    "url": "https://proxy.golang.org/github.com/multiformats/go-varint/@v/v0.1.0.zip"
   },
   {
     "dest": "vendor/github.com/ncruces/go-strftime",
-    "sha256": "3c46ee9c9db8fde8ce93c768a8701fa01f630bab0cfff338481cde768fe561ac",
+    "sha256": "c1a7e718dbf5f779e9fc98b7354ed4d98de2949b83b65837c429b4b2c8c27686",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/ncruces/go-strftime/@v/v0.1.9.zip"
+    "url": "https://proxy.golang.org/github.com/ncruces/go-strftime/@v/v1.0.0.zip"
   },
   {
     "dest": "vendor/github.com/pion/datachannel",
@@ -442,38 +463,38 @@
   },
   {
     "dest": "vendor/github.com/pion/dtls/v3",
-    "sha256": "7de638a3bf9bc6f04bc2b77d0cbbc69c462c6b498848371ea43518c976555bec",
+    "sha256": "4aa6c70d6eed91fa00919626eb88b6d2235060a73d1daccd685437795dcd50ea",
     "strip-components": 4,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/pion/dtls/v3/@v/v3.0.5.zip"
+    "url": "https://proxy.golang.org/github.com/pion/dtls/v3/@v/v3.0.7.zip"
   },
   {
     "dest": "vendor/github.com/pion/ice/v2",
-    "sha256": "633ce897e8362882d04af2658697b1ae1eff9fc6362244275deb3bcdf00de97e",
+    "sha256": "b6dacef0cab22fad2012cdedf9226b002133f39b854198af3385d47e49c0636b",
     "strip-components": 4,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/pion/ice/v2/@v/v2.3.37.zip"
+    "url": "https://proxy.golang.org/github.com/pion/ice/v2/@v/v2.3.38.zip"
   },
   {
     "dest": "vendor/github.com/pion/ice/v4",
-    "sha256": "bcce99d2b425c950e447adfec304b596c49751471a33b024b2b91f5140087d3e",
+    "sha256": "365c583c52d5b7901e3d62425167ab13134403564a7b05eb273d7eb458c80346",
     "strip-components": 4,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/pion/ice/v4/@v/v4.0.7.zip"
+    "url": "https://proxy.golang.org/github.com/pion/ice/v4/@v/v4.0.10.zip"
   },
   {
     "dest": "vendor/github.com/pion/interceptor",
-    "sha256": "941cfc58064e4b609a9baa91619878c9f09b64888ad9f7d941278c026b1c3f64",
+    "sha256": "c0d7542e3c37458cfb286823d3ac6d6c6f63d85c6dd5ee1d04dc3ca0b1b6cc64",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/pion/interceptor/@v/v0.1.37.zip"
+    "url": "https://proxy.golang.org/github.com/pion/interceptor/@v/v0.1.41.zip"
   },
   {
     "dest": "vendor/github.com/pion/logging",
-    "sha256": "5848dfd5a2210e365ade9db28b68ac54bc50b3c879776a01197ed29afa3f121d",
+    "sha256": "b904074dd76009e71b4e4e0e004a2c7862bff0a8690b4f47410c46b172b3830c",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/pion/logging/@v/v0.2.3.zip"
+    "url": "https://proxy.golang.org/github.com/pion/logging/@v/v0.2.4.zip"
   },
   {
     "dest": "vendor/github.com/pion/mdns",
@@ -498,31 +519,31 @@
   },
   {
     "dest": "vendor/github.com/pion/rtcp",
-    "sha256": "df9978a97ef56724ae9a5e7e6b756fba2cf44e99516f5167e33e09985225b836",
+    "sha256": "7f8e057d5c03b36d45b96b9fe0f0aba6491212d37da6d98377b2e8c027fd4ef5",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/pion/rtcp/@v/v1.2.15.zip"
+    "url": "https://proxy.golang.org/github.com/pion/rtcp/@v/v1.2.16.zip"
   },
   {
     "dest": "vendor/github.com/pion/rtp",
-    "sha256": "2b2de944ca5a064a4a0d18e7326ce4138d905dc424830cd53a09a3e79d94cdc1",
+    "sha256": "df7c657f406f4a39fd3ab468cd9dc5a3679ffea94e2994f12b555b9297cfc6a2",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/pion/rtp/@v/v1.8.13.zip"
+    "url": "https://proxy.golang.org/github.com/pion/rtp/@v/v1.8.25.zip"
   },
   {
     "dest": "vendor/github.com/pion/sctp",
-    "sha256": "1701af27b71835f84b1d82f11d61d321f5a0dcc9314eb97ca98e65c269c99e83",
+    "sha256": "c5eef58749496334c45fec8f45cd06ce2e1237ad14bc91c29673961c1790c7be",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/pion/sctp/@v/v1.8.37.zip"
+    "url": "https://proxy.golang.org/github.com/pion/sctp/@v/v1.8.40.zip"
   },
   {
     "dest": "vendor/github.com/pion/sdp/v3",
-    "sha256": "4d190672f5eadb50165aff1ea17b484ba8350baed3f902909eddee34e661ab19",
+    "sha256": "b3fdbcc8f109cc31ecee402d6a2ee74e6a1cc7e13d1c55027fea71c0596f37a6",
     "strip-components": 4,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/pion/sdp/v3/@v/v3.0.11.zip"
+    "url": "https://proxy.golang.org/github.com/pion/sdp/v3/@v/v3.0.16.zip"
   },
   {
     "dest": "vendor/github.com/pion/srtp/v2",
@@ -533,10 +554,10 @@
   },
   {
     "dest": "vendor/github.com/pion/srtp/v3",
-    "sha256": "7f0adb975cb92f6a551e7f2a33bba86363c40e514d241b6c5c914e8be8478cdd",
+    "sha256": "ef42c23adf4188fc18029ef960cfbc13036e3549f004a4c0d6bf7c5857683bc3",
     "strip-components": 4,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/pion/srtp/v3/@v/v3.0.4.zip"
+    "url": "https://proxy.golang.org/github.com/pion/srtp/v3/@v/v3.0.8.zip"
   },
   {
     "dest": "vendor/github.com/pion/stun",
@@ -547,10 +568,10 @@
   },
   {
     "dest": "vendor/github.com/pion/stun/v3",
-    "sha256": "f3af9bbf81a3bb44e50f5282c1a833db11da82639fdd0c55d3a2afbe401c97b1",
+    "sha256": "73cd7253f558ea0694ada3d1ff1a0777bc79b8650e7fbeee56665c548c469352",
     "strip-components": 4,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/pion/stun/v3/@v/v3.0.0.zip"
+    "url": "https://proxy.golang.org/github.com/pion/stun/v3/@v/v3.0.1.zip"
   },
   {
     "dest": "vendor/github.com/pion/transport/v2",
@@ -561,10 +582,10 @@
   },
   {
     "dest": "vendor/github.com/pion/transport/v3",
-    "sha256": "f928764cf558648daed662040cffe863b4ca6f88b3eb721de93de11532070d96",
+    "sha256": "10c9d7600ae4eb0524c132b935d38d638023fc5f8a75878a226051b88367c41c",
     "strip-components": 4,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/pion/transport/v3/@v/v3.0.7.zip"
+    "url": "https://proxy.golang.org/github.com/pion/transport/v3/@v/v3.0.8.zip"
   },
   {
     "dest": "vendor/github.com/pion/turn/v2",
@@ -575,24 +596,24 @@
   },
   {
     "dest": "vendor/github.com/pion/turn/v4",
-    "sha256": "6a4a448d86fe14b6c7e7e70d9787aa6038d112289465e126229d9880b916e130",
+    "sha256": "b19630df172cdcd76b920854e2eff07376f6ff940ecda9732099f00c7d50b7ce",
     "strip-components": 4,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/pion/turn/v4/@v/v4.0.0.zip"
+    "url": "https://proxy.golang.org/github.com/pion/turn/v4/@v/v4.1.2.zip"
   },
   {
     "dest": "vendor/github.com/pion/webrtc/v3",
-    "sha256": "150ebae12ceff8ed60d4ebba8b45d3fe6a3fb2d0eae963cf62f3473ff54a165c",
+    "sha256": "7b667a2ba83afc661334adc625809c3a999a6e6f5ddc83a07531443b490f5cc1",
     "strip-components": 4,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/pion/webrtc/v3/@v/v3.3.5.zip"
+    "url": "https://proxy.golang.org/github.com/pion/webrtc/v3/@v/v3.3.6.zip"
   },
   {
     "dest": "vendor/github.com/pion/webrtc/v4",
-    "sha256": "598734ff1169b7eb343fa3a6fe61d0e2e7db5081ed5b065b5fe17c7e257326db",
+    "sha256": "c54f61d4d84752818e7b726e61104431cd3b6857325e23e7f960e5b4db58f7fe",
     "strip-components": 4,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/pion/webrtc/v4/@v/v4.0.13.zip"
+    "url": "https://proxy.golang.org/github.com/pion/webrtc/v4/@v/v4.1.6.zip"
   },
   {
     "dest": "vendor/github.com/pkg/errors",
@@ -645,17 +666,17 @@
   },
   {
     "dest": "vendor/github.com/stretchr/testify",
-    "sha256": "36c87573527a97ce97fc15ce2a101e65e5ebb350db142d09f633580cb8d5c839",
+    "sha256": "b7325b561ead5304b72b9f32aebc871ff49b3823667d530a49fd6c8f3adfc96e",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/stretchr/testify/@v/v1.10.0.zip"
+    "url": "https://proxy.golang.org/github.com/stretchr/testify/@v/v1.11.1.zip"
   },
   {
     "dest": "vendor/github.com/tidwall/btree",
-    "sha256": "4a6619eb936c836841702933a9d66f27abe83b7ffb541de44d12db4aa3a809d5",
+    "sha256": "f0be94aae6cc3dcd394af929859a95b24c6f67874438d7d4b1661e346929eeb0",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/github.com/tidwall/btree/@v/v1.7.0.zip"
+    "url": "https://proxy.golang.org/github.com/tidwall/btree/@v/v1.8.1.zip"
   },
   {
     "dest": "vendor/github.com/wlynxg/anet",
@@ -666,94 +687,108 @@
   },
   {
     "dest": "vendor/go.etcd.io/bbolt",
-    "sha256": "6da6afab4dabc4253e26549d7e32928c105eaede15b93cb704f58e2b0f64b21e",
+    "sha256": "3110374ed5e6984200e6360b6488312803fb41516fff556b350d2a1abaa5ecb5",
     "strip-components": 2,
     "type": "archive",
-    "url": "https://proxy.golang.org/go.etcd.io/bbolt/@v/v1.4.0.zip"
+    "url": "https://proxy.golang.org/go.etcd.io/bbolt/@v/v1.4.3.zip"
   },
   {
     "dest": "vendor/go.opentelemetry.io/auto/sdk",
-    "sha256": "006d3a5a7292d11f093ce65fcd5a15d15fb7bd11d0e066503f91bd64c4bffe2c",
+    "sha256": "a08a16fc0a7041cdb875f47a260a56000632212c85f65a302a043c76380c8335",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/go.opentelemetry.io/auto/sdk/@v/v1.1.0.zip"
+    "url": "https://proxy.golang.org/go.opentelemetry.io/auto/sdk/@v/v1.2.1.zip"
   },
   {
     "dest": "vendor/go.opentelemetry.io/otel",
-    "sha256": "db49129d417338ed3517e7ec6f3e894e6828152488731fe832690041892d341d",
+    "sha256": "1f9f344b9f15382834c7f2ea15f13ca1d0516c98116c59e7bb29fed0b4748d8a",
     "strip-components": 2,
     "type": "archive",
-    "url": "https://proxy.golang.org/go.opentelemetry.io/otel/@v/v1.35.0.zip"
+    "url": "https://proxy.golang.org/go.opentelemetry.io/otel/@v/v1.38.0.zip"
   },
   {
     "dest": "vendor/go.opentelemetry.io/otel/metric",
-    "sha256": "c30a5fadd4eb1a801561199ef7da0012102ac87be12964f708472e919e2ef29c",
+    "sha256": "39dc88030971236b0cbba0d94a834c448d9301ceec749f717994a2a7f9ab838d",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/go.opentelemetry.io/otel/metric/@v/v1.35.0.zip"
+    "url": "https://proxy.golang.org/go.opentelemetry.io/otel/metric/@v/v1.38.0.zip"
   },
   {
     "dest": "vendor/go.opentelemetry.io/otel/trace",
-    "sha256": "24f3abd562a9c2d18208b9716a7ff65d4b56567a13ce7d3a4fe6666251375e6a",
+    "sha256": "f040f84581707a0123aec182596cd34700860e7866f556e7900ac4c17233150e",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/go.opentelemetry.io/otel/trace/@v/v1.35.0.zip"
-  },
-  {
-    "dest": "vendor/go4.org/unsafe/assume-no-moving-gc",
-    "sha256": "e9f5fa7ec7ae45153c6cb5b0c21e813860f9a4370b35ed1ab27398ba365dbb43",
-    "strip-components": 3,
-    "type": "archive",
-    "url": "https://proxy.golang.org/go4.org/unsafe/assume-no-moving-gc/@v/v0.0.0-20231121144256-b99613f794b6.zip"
+    "url": "https://proxy.golang.org/go.opentelemetry.io/otel/trace/@v/v1.38.0.zip"
   },
   {
     "dest": "vendor/golang.org/x/crypto",
-    "sha256": "86bb4875b3d2bd173b820d2d81d4ae630508fa65183a44dac2cb915e4f904180",
+    "sha256": "0b11e4f2ac759849fc2567213e22e7dcb2e1bfe9755aca46c95d8d253f3c610b",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/golang.org/x/crypto/@v/v0.36.0.zip"
+    "url": "https://proxy.golang.org/golang.org/x/crypto/@v/v0.43.0.zip"
   },
   {
     "dest": "vendor/golang.org/x/exp",
-    "sha256": "18d5e88d3389cbfb181eb9cc36235349129620bfb6df15b1bfd1d936638cd73b",
+    "sha256": "183b4540aeac7bf32f85390038801ce4c08a268037243220e4415718e12ad719",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/golang.org/x/exp/@v/v0.0.0-20250305212735-054e65f0b394.zip"
+    "url": "https://proxy.golang.org/golang.org/x/exp/@v/v0.0.0-20251023183803-a4bb9ffd2546.zip"
+  },
+  {
+    "dest": "vendor/golang.org/x/mod",
+    "sha256": "7c736672c72aa571b65c1106bbb2a64e587dd4265a18f0059c990f95c5117962",
+    "strip-components": 3,
+    "type": "archive",
+    "url": "https://proxy.golang.org/golang.org/x/mod/@v/v0.29.0.zip"
   },
   {
     "dest": "vendor/golang.org/x/net",
-    "sha256": "5ac3c526c078cbccfb600ae49acd21705ba97e9f70e7812618cbb0616985df83",
+    "sha256": "ab1748b2a509ab17fdca7a1101faf0e0c1879dec0ed98e2a72830449356d70d2",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/golang.org/x/net/@v/v0.37.0.zip"
+    "url": "https://proxy.golang.org/golang.org/x/net/@v/v0.46.0.zip"
   },
   {
     "dest": "vendor/golang.org/x/oauth2",
-    "sha256": "8bc84624e7da8ee85e022e261828e4257ace89953b0ac1115a83f320e608db02",
+    "sha256": "64c855b335cc2e90b2d88c1fe6c3a31de53c3ca76fc9c89e6ce266c7334b768b",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/golang.org/x/oauth2/@v/v0.28.0.zip"
+    "url": "https://proxy.golang.org/golang.org/x/oauth2/@v/v0.32.0.zip"
   },
   {
     "dest": "vendor/golang.org/x/sync",
-    "sha256": "a35481e5ae73e51ef01cf42bcad09c3b73bb3a4abb67d495d4a575021541ed02",
+    "sha256": "c5dcfd32e223edc7a003a51a166a81759a4beccb9a91eb85385b4d67a1c820c6",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/golang.org/x/sync/@v/v0.12.0.zip"
+    "url": "https://proxy.golang.org/golang.org/x/sync/@v/v0.17.0.zip"
   },
   {
     "dest": "vendor/golang.org/x/sys",
-    "sha256": "55f8255602c7a68419745943298893f0a83d6d6696199cfe6b644054669509f3",
+    "sha256": "6c87bb94ec328b6d6234ad02cf2813225fe3bd5f8929fe85775ca06e01cfcc78",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/golang.org/x/sys/@v/v0.31.0.zip"
+    "url": "https://proxy.golang.org/golang.org/x/sys/@v/v0.37.0.zip"
+  },
+  {
+    "dest": "vendor/golang.org/x/text",
+    "sha256": "4953efaff3130e642c94ffb8624f668fb9ccfb780757a7e87f86a2434559d934",
+    "strip-components": 3,
+    "type": "archive",
+    "url": "https://proxy.golang.org/golang.org/x/text/@v/v0.30.0.zip"
   },
   {
     "dest": "vendor/golang.org/x/time",
-    "sha256": "a94a0e3766428c1b0acb6f33d8e97f162403530d993938c1741088f6d2a4cd13",
+    "sha256": "0e2d2e47d107859130c7088346966d99a14ec0f7a42290c4acc0e2cc568e7a81",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/golang.org/x/time/@v/v0.11.0.zip"
+    "url": "https://proxy.golang.org/golang.org/x/time/@v/v0.14.0.zip"
+  },
+  {
+    "dest": "vendor/golang.org/x/xerrors",
+    "sha256": "07ee9f680118861ee732ce0df4553b834383b87e0519fb9a0990c51d7abd6885",
+    "strip-components": 3,
+    "type": "archive",
+    "url": "https://proxy.golang.org/golang.org/x/xerrors/@v/v0.0.0-20240903120638-7835f813f4da.zip"
   },
   {
     "dest": "vendor/gopkg.in/yaml.v3",
@@ -764,17 +799,17 @@
   },
   {
     "dest": "vendor/lukechampine.com/blake3",
-    "sha256": "13c03f7f70a6ada6f34ead31b6474a7d1090f03c369e263f1432aa031e213da0",
+    "sha256": "b3a3338a6e830b79fb2ff1d263f07f3fe0adcfbafd04b65e5fe14415613e2e4d",
     "strip-components": 2,
     "type": "archive",
-    "url": "https://proxy.golang.org/lukechampine.com/blake3/@v/v1.4.0.zip"
+    "url": "https://proxy.golang.org/lukechampine.com/blake3/@v/v1.4.1.zip"
   },
   {
     "dest": "vendor/modernc.org/libc",
-    "sha256": "e2dedd02d66fba5a642ad7c982e992341b72dabd2be4a058ba55e7c32427c97a",
+    "sha256": "13b5546ba69b4451d17cca2a62366d1d6249f46e6682a5c62abd51e132dc9b88",
     "strip-components": 2,
     "type": "archive",
-    "url": "https://proxy.golang.org/modernc.org/libc/@v/v1.61.13.zip"
+    "url": "https://proxy.golang.org/modernc.org/libc/@v/v1.66.10.zip"
   },
   {
     "dest": "vendor/modernc.org/mathutil",
@@ -785,23 +820,23 @@
   },
   {
     "dest": "vendor/modernc.org/memory",
-    "sha256": "81c537e4da9781fc82943aa76d574c80e70a2fcc538ce0137825a8e387cd4ad1",
+    "sha256": "4930b81d10818a6d11497204fe06b2edc359136a7881586363caa694c8607d0c",
     "strip-components": 2,
     "type": "archive",
-    "url": "https://proxy.golang.org/modernc.org/memory/@v/v1.8.2.zip"
+    "url": "https://proxy.golang.org/modernc.org/memory/@v/v1.11.0.zip"
   },
   {
     "dest": "vendor/modernc.org/sqlite",
-    "sha256": "eea024d3f2ab81d63bfd54f17b4ba2667aa1e982f85981e1e0af3f7365a79f10",
+    "sha256": "77753672dac0e0a44d917f206ca031c27e8b0404da14afd6b5c384c354bbeee1",
     "strip-components": 2,
     "type": "archive",
-    "url": "https://proxy.golang.org/modernc.org/sqlite/@v/v1.36.0.zip"
+    "url": "https://proxy.golang.org/modernc.org/sqlite/@v/v1.40.0.zip"
   },
   {
     "dest": "vendor/zombiezen.com/go/sqlite",
-    "sha256": "dfdb6a520a6ede0530d262aa7b37e9e37df5d98d2bc28731016fd8377af55735",
+    "sha256": "21c88e853d4a7a6601145961980b605f157535c55304796bbfd96dc3e97c39d0",
     "strip-components": 3,
     "type": "archive",
-    "url": "https://proxy.golang.org/zombiezen.com/go/sqlite/@v/v1.4.0.zip"
+    "url": "https://proxy.golang.org/zombiezen.com/go/sqlite/@v/v1.4.2.zip"
   }
 ]


### PR DESCRIPTION
This bumps the GNOME runtime since 47 became EOL. It does not update to the latest Multiplex version yet since we haven't done a proper release as some upstreaming work to the underlying libraries is still WIP.